### PR TITLE
Disabled chrome extensions

### DIFF
--- a/generators/app/templates/src/test/resources/GebConfig.groovy
+++ b/generators/app/templates/src/test/resources/GebConfig.groovy
@@ -1,4 +1,5 @@
 import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.ChromeOptions
 import org.openqa.selenium.firefox.FirefoxDriver
 import org.openqa.selenium.phantomjs.PhantomJSDriver
 

--- a/generators/app/templates/src/test/resources/GebConfig.groovy
+++ b/generators/app/templates/src/test/resources/GebConfig.groovy
@@ -3,12 +3,14 @@ import org.openqa.selenium.firefox.FirefoxDriver
 import org.openqa.selenium.phantomjs.PhantomJSDriver
 
 waiting {
-	timeout = 5
+	timeout = 10
 }
 
 environments {
 	chrome {
-		driver = { new ChromeDriver() }
+    ChromeOptions options = new ChromeOptions()
+    options.addArguments("--disable-extensions")
+		driver = { new ChromeDriver(options) }
 	}
 
 	firefox {


### PR DESCRIPTION
added chrome options to disable extensions because there is sometimes a dialog that will pop up and get in the way of tests
