### PR TITLE
Update geb, selenium, and chromedriver versions. Change chromedriver to use mac64

### DIFF
--- a/generators/app/templates/build.gradle
+++ b/generators/app/templates/build.gradle
@@ -6,9 +6,9 @@ ext {
 
   ext {
     groovyVersion = '2.4.1'
-    gebVersion = '0.12.2'
-    seleniumVersion = '2.46.0'
-    chromeDriverVersion = '2.19'
+    gebVersion = '2.1'
+    seleniumVersion = '3.12.0'
+    chromeDriverVersion = '2.38'
     phantomJsVersion = '1.9.7'
   }
 }

--- a/generators/app/templates/gradle/osSpecificDownloads.gradle
+++ b/generators/app/templates/gradle/osSpecificDownloads.gradle
@@ -20,7 +20,7 @@ task downloadChromeDriver {
 		if (Os.isFamily(Os.FAMILY_WINDOWS)) {
 			driverOsFilenamePart = "win32"
 		} else if (Os.isFamily(Os.FAMILY_MAC)) {
-			driverOsFilenamePart = "mac32"
+      driverOsFilenamePart = "mac64"
 		} else if (Os.isFamily(Os.FAMILY_UNIX)) {
 			driverOsFilenamePart = Os.isArch("amd64") ? "linux64" : "linux32"
 		}


### PR DESCRIPTION
Updated a few things:
1. ChromeDriver mac32 is no longer supported, so it was changed to mac64
2. An update to chrome in the last year required the selenium version, geb version, and chrome driver versions to be updated